### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/core/operations/JSONBeautify.mjs
+++ b/src/core/operations/JSONBeautify.mjs
@@ -163,7 +163,7 @@ function json2html(json, options) {
             html += `<a href="${json}" class="json-string" target="_blank">${json}</a>`;
         } else {
             // Escape double quotes in the rendered non-URL string.
-            json = json.replace(/&quot;/g, "\\&quot;");
+            json = json.replace(/\\/g, "\\\\").replace(/&quot;/g, "\\&quot;");
             html += `<span class="json-string">"${json}"</span>`;
         }
     } else if (typeof json === "number" || typeof json === "bigint") {


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/4](https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/4)

To fix the issue, we need to ensure that backslashes are properly escaped in the `json.replace` logic. This can be achieved by adding a preceding step to replace all backslashes (`\`) with double backslashes (`\\`) before handling double quotes. This ensures that any backslashes in the input are correctly escaped, preventing malformed output or potential security issues.

The fix involves:
1. Adding a `replace` call to escape backslashes before escaping double quotes.
2. Using a regular expression with the global (`g`) flag to ensure all occurrences are replaced.

The updated logic will first replace backslashes and then handle double quotes, ensuring complete escaping.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
