### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/web/waiters/BindingsWaiter.mjs
+++ b/src/web/waiters/BindingsWaiter.mjs
@@ -298,7 +298,7 @@ class BindingsWaiter {
             helpTitle = "<span class='text-muted'>Help topic</span>";
 
         document.querySelector("#help-modal .modal-body").innerHTML = helpText;
-        document.querySelector("#help-modal #help-title").innerHTML = helpTitle;
+        document.querySelector("#help-modal #help-title").textContent = helpTitle;
 
         $("#help-modal").modal();
     }


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/2](https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/2)

To fix the issue, the untrusted data retrieved from `el.getAttribute("data-help-title")` must be sanitized or escaped before being assigned to `innerHTML`. Escaping ensures that any special characters in the string are treated as plain text rather than HTML, preventing XSS attacks.

The best way to fix this is to use a library or built-in function to escape the string before assigning it to `innerHTML`. In this case, `helpTitle` can be escaped using `textContent` or a utility function like `DOMPurify` for more robust sanitization.

Changes to make:
1. Replace the direct assignment of `helpTitle` to `innerHTML` with an escaped or sanitized version.
2. Add any necessary imports or utility functions for escaping.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
