### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/src/core/operations/PHPDeserialize.mjs
+++ b/src/core/operations/PHPDeserialize.mjs
@@ -151,7 +151,7 @@ class PHPDeserialize extends Operation {
                     const value = read(length);
                     expect('";');
                     if (args[0]) {
-                        return '"' + value.replace(/"/g, '\\"') + '"'; // lgtm [js/incomplete-sanitization]
+                        return '"' + value.replace(/["\\]/g, '\\$&') + '"'; // lgtm [js/incomplete-sanitization]
                     } else {
                         return '"' + value + '"';
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/5](https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/5)

To fix the issue, the `value.replace` operation should be updated to escape both double-quote characters (`"`) and backslash characters (`\`). This can be achieved by using a regular expression that matches both characters and replaces them with their escaped versions. Specifically, the regular expression `/["\\]/g` matches both double quotes and backslashes, and the replacement string `\\$&` ensures that each matched character is prefixed with a backslash.

The fix involves modifying line 154 to use this updated regular expression and replacement logic. No additional imports or dependencies are required, as the `replace` method and regular expressions are native to JavaScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
