### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/src/core/Utils.mjs
+++ b/src/core/Utils.mjs
@@ -1022,6 +1022,7 @@ class Utils {
         while ((m = recipeRegex.exec(recipe))) {
             // Translate strings in args back to double-quotes
             args = m[2] // lgtm [js/incomplete-sanitization]
+                .replace(/\\/g, "\\\\") // Escape backslashes
                 .replace(/"/g, '\\"') // Escape double quotes
                 .replace(/(^|,|{|:)'/g, '$1"') // Replace opening ' with "
                 .replace(/([^\\]|(?:\\\\)+)'(,|:|}|$)/g, '$1"$2') // Replace closing ' with "


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/3](https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/3)

To fix the issue, we need to ensure that backslashes in the input (`m[2]`) are properly escaped before the string is processed further. This can be achieved by adding a `.replace` call to escape backslashes (`\`) by replacing them with double backslashes (`\\`). This step should be performed before handling other escape sequences to avoid conflicts or unintended behavior.

The fix involves modifying the sanitization logic for `m[2]` in the `parseRecipeConfig` method. Specifically, we will add a `.replace(/\\/g, "\\\\")` call to escape all backslashes globally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
