### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/web/waiters/BindingsWaiter.mjs
+++ b/src/web/waiters/BindingsWaiter.mjs
@@ -297,7 +297,7 @@ class BindingsWaiter {
         else
             helpTitle = "<span class='text-muted'>Help topic</span>";
 
-        document.querySelector("#help-modal .modal-body").innerHTML = helpText;
+        document.querySelector("#help-modal .modal-body").textContent = helpText;
         document.querySelector("#help-modal #help-title").textContent = helpTitle;
 
         $("#help-modal").modal();


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/1](https://github.com/NanashiTheNameless/CyberChef/security/code-scanning/1)

To fix the issue, the `helpText` variable should be sanitized or escaped before being assigned to `innerHTML`. The best approach is to use a method that ensures the text is treated as plain text rather than HTML. This can be achieved by assigning the sanitized text to the `textContent` property instead of `innerHTML`. 

**Steps to fix:**
1. Replace the assignment to `innerHTML` with an assignment to `textContent` to ensure the text is treated as plain text.
2. Update the relevant code in the `displayHelp` method in `BindingsWaiter.mjs`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
